### PR TITLE
Add `--recipe-file` flag to run recipe from a file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,15 +257,16 @@ shef [category] [recipe-name]
 
 ### Global Flags
 
-| Flag             | Description                |
-|------------------|----------------------------|
-| `-h, --help`     | Show help information      |
-| `-v, --version`  | Show version information   |
-| `-d, --debug`    | Enable debug output        |
-| `-c, --category` | Specify a category         |
-| `-L, --local`    | Force local recipes first  |
-| `-U, --user`     | Force user recipes first   |
-| `-P, --public`   | Force public recipes first |
+| Flag                  | Description                |
+|-----------------------|----------------------------|
+| `-h, --help`          | Show help information      |
+| `-v, --version`       | Show version information   |
+| `-d, --debug`         | Enable debug output        |
+| `-c, --category`      | Specify a category         |
+| `-L, --local`         | Force local recipes first  |
+| `-U, --user`          | Force user recipes first   |
+| `-P, --public`        | Force public recipes first |
+| `-r, --recipe-file`   | Path to the recipe file    |
 
 ### Utility Commands
 

--- a/main.go
+++ b/main.go
@@ -1284,7 +1284,7 @@ func main() {
 			&cli.PathFlag{
 				Name:    "recipe-file",
 				Aliases: []string{"r"},
-				Usage:   "Execute a recipe",
+				Usage:   "Path to the recipe file",
 			},
 		},
 		Action: func(c *cli.Context) error {

--- a/main.go
+++ b/main.go
@@ -1281,6 +1281,11 @@ func main() {
 				Aliases: []string{"c"},
 				Usage:   "Filter by category",
 			},
+			&cli.PathFlag{
+				Name:    "recipe-file",
+				Aliases: []string{"r"},
+				Usage:   "Execute a recipe",
+			},
 		},
 		Action: func(c *cli.Context) error {
 			args := c.Args().Slice()
@@ -1408,6 +1413,12 @@ func outputRecipesAsJSON(recipes []Recipe) error {
 }
 
 func handleRunCommand(c *cli.Context, args []string, sourcePriority []string) error {
+	recipeFilePath := c.String("recipe-file")
+
+	if recipeFilePath != "" {
+		return runRecipeFromPath(recipeFilePath)
+	}
+
 	if len(args) == 0 {
 		return fmt.Errorf("no recipe specified. Use shef ls to list available recipes")
 	}
@@ -1434,6 +1445,22 @@ func handleRunCommand(c *cli.Context, args []string, sourcePriority []string) er
 	}
 
 	return executeRecipe(*recipe, debug)
+}
+
+func runRecipeFromPath(filePath string) error {
+	contents, err := loadConfig(filePath)
+
+	if err != nil {
+		return err
+	}
+
+	for _, recipe := range contents.Recipes {
+		if err := executeRecipe(recipe, false); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func findRecipeInSources(recipeName, category string, sourcePriority []string) (*Recipe, error) {


### PR DESCRIPTION
### What?
This PR adds a new --recipe-file flag to the shef command. when it's used with shef command `shef --recipe-file recipes/demo/hello-world.yaml` it will execute that recipe file.

### Why?
It will be an obvious flag that a power user might want